### PR TITLE
Implement `get/lands` module

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,4 +10,6 @@ dependencies:
     - coveralls
     - click==7.1.2
     - coverage==5.1
+    - tqdm
+    - requests
 prefix: /Users/tony/miniconda3/envs/landwatch

--- a/landwatch/__init__.py
+++ b/landwatch/__init__.py
@@ -1,1 +1,2 @@
+PACKAGE_NAME = "landwatch"
 # from .__main__ import SUBMODULES, cli_main

--- a/landwatch/__main__.py
+++ b/landwatch/__main__.py
@@ -1,4 +1,5 @@
+from . import PACKAGE_NAME
 from .cli import cli_main
 
 if __name__ == "__main__":
-    cli_main()
+    cli_main(prog_name=PACKAGE_NAME)

--- a/landwatch/cli.py
+++ b/landwatch/cli.py
@@ -1,4 +1,5 @@
 import os
+from . import PACKAGE_NAME
 from importlib import import_module
 
 import click
@@ -9,7 +10,7 @@ SUBMODULES = [
      if not m.startswith('__')
 ]
 # Set up CLI group.
-@click.group()
+@click.group(name=PACKAGE_NAME)
 def cli_main():
     pass
 

--- a/landwatch/get/NOTES.md
+++ b/landwatch/get/NOTES.md
@@ -23,6 +23,9 @@ Some of these data types are derived from a single source (e.g. both legislation
 | Legislation | Congress API | API | ProPublica | https://projects.propublica.org/api-docs/congress-api/ | Member data, bill data, floor actions, committee data |
 | Public Lands | Protected Areas Database | Data Download | USGS | https://www.usgs.gov/core-science-systems/science-analytics-and-synthesis/gap/science/pad-us-data-download?qt-science_center_objects=0#qt-science_center_objects | From the Gap Analysis Project  |
 
+Other Notes:
+* [WDPA Documentation / Manual](http://wdpa.s3.amazonaws.com/WDPA_Manual/English/WDPA_Manual_1_4_EN_FINAL.pdf)
+
 ## Implementation Strategy
 
 The implementation of each data type will be as a sub-module (`.py`) within this `get` directory. Each type (`lands`, `bills`, `sponsors`, and `finance`) will have its own file. These modules will contain a class implementing various domain-specific functions. These are not yet enumerated. All will eventually have a `save` or similar command which writes final output to a flatfile/csv.

--- a/landwatch/get/__init__.py
+++ b/landwatch/get/__init__.py
@@ -1,10 +1,10 @@
 import click
-from .lands import download
+from .lands import _cli
 
 @click.group()
 def get():
-    pass
+    pass # pragma: no cover
 
-get.add_command(download)
+get.add_command(_cli)
 
 _cli = get

--- a/landwatch/get/__init__.py
+++ b/landwatch/get/__init__.py
@@ -2,6 +2,6 @@ import click
 
 @click.command()
 def get():
-    click.echo("Get has been called.")
+    pass
 
 _cli = get

--- a/landwatch/get/__init__.py
+++ b/landwatch/get/__init__.py
@@ -1,7 +1,10 @@
 import click
+from .lands import download
 
-@click.command()
+@click.group()
 def get():
     pass
+
+get.add_command(download)
 
 _cli = get

--- a/landwatch/get/lands.py
+++ b/landwatch/get/lands.py
@@ -1,5 +1,0 @@
-import click
-
-@click.command()
-def download():
-    click.echo("Downloading...(dummy)")

--- a/landwatch/get/lands.py
+++ b/landwatch/get/lands.py
@@ -1,0 +1,5 @@
+import click
+
+@click.command()
+def download():
+    click.echo("Downloading...(dummy)")

--- a/landwatch/get/lands/NOTES.md
+++ b/landwatch/get/lands/NOTES.md
@@ -1,0 +1,16 @@
+We're starting with the USGS [Protected Areas Database (PAD)](https://www.usgs.gov/core-science-systems/science-analytics-and-synthesis/gap/science/pad-us-data-overview?qt-science_center_objects=0#qt-science_center_objects).
+
+## PAD-US data features
+
+PAD-US is available as a zipped national, DOI Region, or state geodatabase or shapefile. The following are included in PAD-US:
+
+* Geographic boundaries of public land ownership (primarily Federal and State, local government data is incorporated with increasing frequency) and voluntarily provided private conservation lands (e.g., Nature Conservancy Preserves or land trust easements) from authoritative data sources.
+* Standardized and original land owner, land manager, management designation and parcel name descriptions, areas and the source of geographic information of each mapped land unit.
+* GAP Status Code – conservation measure of each parcel based on protection level categories that provide a measure of management intent for the long-term protection of biodiversity.
+* IUCN category – a globally inter operable conservation measure required for a protected area’s inclusion into UNEP-World Conservation Monitoring Centre’s (WCMC) World Database on Protected Areas (WDPA).
+* Reference information – aggregator source and original GIS source and dates.
+* See “Supplemental_Info.txt” and metadata files included in download for more information.
+
+## Known Limitations
+
+Some agencies seem to have only submitted partial accounts of the land under their jurisdiction. "For example, Federal agencies estimate the percent completeness of lands data submitted for PAD-US 2.0 as: NPS (95%), USFS (99%), FWS (89%), BLM (85%), USACE (80%), DOD (79%), USBR (50%), NRCS (85%), BOEM (95%), NOAA (95%)." [source](https://www.sciencebase.gov/catalog/file/get/5b030c7ae4b0da30c1c1d6de?f=__disk__27/0c/5d/270c5df419901e7060f0a4d08076a6ff6d8889bd&transform=1&allowOpen=true#Data%20Quality%20Information)

--- a/landwatch/get/lands/__init__.py
+++ b/landwatch/get/lands/__init__.py
@@ -1,0 +1,4 @@
+import click
+from .cli import lands
+
+_cli = lands

--- a/landwatch/get/lands/cli.py
+++ b/landwatch/get/lands/cli.py
@@ -1,0 +1,43 @@
+import click
+from .usgs import USGSProtectedLands
+from .wdpa import WDPA
+
+
+@click.group(
+    help= "Download public lands data. Currently supports USGS and WDPA data (specify as TYPE positional argument).")
+@click.argument("type")
+@click.pass_context
+def lands(ctx, type):
+    ctx.ensure_object(dict)
+    ctx.obj['type'] = type
+
+
+@lands.command(
+    help = "Download public lands data."
+)
+# @click.argument("type")
+# @click.argument("dest")
+@click.pass_context
+def download(ctx):
+    """Download public lands data."""
+    if ctx.obj['type'] == "usgs":
+        _data = USGSProtectedLands()
+    if ctx.obj['type'] == "wdpa":
+        _data = WDPA()
+    else:
+        raise click.UsageError(f"Data type \"{ctx.obj['type']}\" is not supported.")
+    _data.download(dest)
+
+@lands.command(help="Unzip already-downloaded data")
+@click.argument("data")
+@click.argument("dest")
+@click.pass_context
+def unzip(ctx, data, dest):
+    if  ctx.obj['type'] == "usgs":
+        _data = USGSProtectedLands(local_loc=data)
+    if  ctx.obj['type'] == 'wdpa':
+        _data = WDPA(local_loc=data)
+    else:
+        click.UsageError(f"Data type \"{ctx.obj['type']}\" is not supported.")
+
+    _data.unzip(dest)

--- a/landwatch/get/lands/cli.py
+++ b/landwatch/get/lands/cli.py
@@ -49,6 +49,7 @@ def unzip(ctx, data, dest):
 @lands.command(help="Process unzipped raw data to Spatialite db (see docs).")
 @click.argument("source")
 @click.option("-d", "--destination", help="Destination. Defaults to original source location.")
+@click.option("--all", help="Output entire PAD-US (if not given, output only contains federally-managed land)")
 @click.pass_context
 def savedb(ctx, source, destination):
     if ctx.obj['type'] == 'usgs':

--- a/landwatch/get/lands/cli.py
+++ b/landwatch/get/lands/cli.py
@@ -45,3 +45,14 @@ def unzip(ctx, data, dest):
         click.UsageError(f"Data type \"{ctx.obj['type']}\" is not supported.")
 
     _data.unzip(dest)
+
+@lands.command(help="Process unzipped raw data to Spatialite db (see docs).")
+@click.argument("source")
+@click.option("-d", "--destination", help="Destination. Defaults to original source location.")
+@click.pass_context
+def savedb(ctx, source, destination):
+    if ctx.obj['type'] == 'usgs':
+        _data = USGSProtectedLands(local_loc=source)
+    else:
+        click.UsageError(f"Data type \"{ctx.obj['type']}\" is not supported.")
+    _data.savedb(destination=destination)

--- a/landwatch/get/lands/cli.py
+++ b/landwatch/get/lands/cli.py
@@ -12,22 +12,26 @@ def lands(ctx, type):
     ctx.obj['type'] = type
 
 
+## Data Download Command
 @lands.command(
     help = "Download public lands data."
 )
 # @click.argument("type")
-# @click.argument("dest")
+@click.argument("dest")
 @click.pass_context
-def download(ctx):
+def download(ctx, dest):
     """Download public lands data."""
+    print(ctx.obj['type'] == "usgs")
     if ctx.obj['type'] == "usgs":
         _data = USGSProtectedLands()
-    if ctx.obj['type'] == "wdpa":
+        _data.download(dest)
+    elif ctx.obj['type'] == "wdpa":
         _data = WDPA()
     else:
         raise click.UsageError(f"Data type \"{ctx.obj['type']}\" is not supported.")
     _data.download(dest)
 
+## Data Unzip Command
 @lands.command(help="Unzip already-downloaded data")
 @click.argument("data")
 @click.argument("dest")

--- a/landwatch/get/lands/usgs.py
+++ b/landwatch/get/lands/usgs.py
@@ -1,0 +1,67 @@
+import os
+
+from warnings import warn
+from ..util import _download_file
+
+from tempfile import TemporaryDirectory
+
+from subprocess import Popen
+
+import requests
+
+
+"""
+usgs.py
+Tony Cannistra
+
+Manages the data access of USGS datasets, including:
+    * Protected Areas Database (PAD-US) 2.0
+
+"""
+
+UNZIP_CMD = "unzip -u -o {zipfile} -d {outdir}"
+
+class USGSProtectedLands(object):
+    """Access USGS Protected Lands data"""
+    ZIP_SHP_DATA_URL = "https://www.sciencebase.gov/catalog/file/get/5b030c7ae4b0da30c1c1d6de?f=__disk__97%2F0a%2F32%2F970a32899eb4389aaf8b3abf61b6bc7fde229df8"
+    DATA_FILENAME = "USGSPAD.shp.zip"
+    def __init__(self, local_loc=None):
+        self.local_loc = local_loc
+
+    def unzip(self, destination, zipfile=None):
+        """Unzip USGS Protected Lands database file. Uses local_loc if zipfile is not specified"""
+        if zipfile is None:
+            zipfile = self.local_loc
+
+        if not os.path.exists(destination):
+            warn(f"Directory {destination} does not exist; creating...")
+            os.makedirs(destination)
+
+        Popen(UNZIP_CMD.format(
+            zipfile = zipfile,
+            outdir = os.path.join(destination, "usgs_pad.shp")
+        ), shell=True).communicate()
+
+    def download(self, destination):
+        """
+        Download and unzip PAD-US data into destination.
+
+        Throws warning if local_loc was given at class initialization,
+        re-downloading may be unnecessary in this case.
+        """
+        if self.local_loc:
+            warn("Local location of dataset already provided."
+                 "Re-running download in this case will result"
+                 "in extra bandwidth usage and download times.")
+
+        print("Downloading...")
+        with TemporaryDirectory() as td:
+            tmpfile = os.path.join(td, "pad-us.zip")
+
+            _download_file(USGSProtectedLands.ZIP_SHP_DATA_URL, tmpfile)
+
+            print("Unzipping file...")
+            Popen(UNZIP_CMD.format(
+                zipfile = tmpfile,
+                outdir = os.path.join(destination, "usgs_pad.shp")
+            ), shell=True).communicate()

--- a/landwatch/get/lands/usgs.py
+++ b/landwatch/get/lands/usgs.py
@@ -25,8 +25,9 @@ class USGSProtectedLands(object):
     """Access USGS Protected Lands data"""
     ZIP_SHP_DATA_URL = "https://www.sciencebase.gov/catalog/file/get/5b030c7ae4b0da30c1c1d6de?f=__disk__97%2F0a%2F32%2F970a32899eb4389aaf8b3abf61b6bc7fde229df8"
     DATA_FILENAME = "USGSPAD.shp.zip"
-    def __init__(self, local_loc=None):
+    def __init__(self, local_loc=None, alternate_src=None):
         self.local_loc = local_loc
+        self.alternate_src = alternate_src
 
     def unzip(self, destination, zipfile=None):
         """Unzip USGS Protected Lands database file. Uses local_loc if zipfile is not specified"""
@@ -55,12 +56,15 @@ class USGSProtectedLands(object):
                  "in extra bandwidth usage and download times.")
 
         print("Downloading...")
+        srcpath = self.alternate_src if self.alternate_src else ZIP_SHP_DATA_URL
         with TemporaryDirectory() as td:
             tmpfile = os.path.join(td, "pad-us.zip")
 
-            _download_file(USGSProtectedLands.ZIP_SHP_DATA_URL, tmpfile)
+            _download_file(srcpath, tmpfile)
 
             print("Unzipping file...")
+
+
             Popen(UNZIP_CMD.format(
                 zipfile = tmpfile,
                 outdir = os.path.join(destination, "usgs_pad.shp")

--- a/landwatch/get/lands/wdpa.py
+++ b/landwatch/get/lands/wdpa.py
@@ -1,0 +1,82 @@
+import os
+
+from warnings import warn
+from ..util import _download_file, _unzip
+
+from tempfile import TemporaryDirectory
+
+from subprocess import Popen
+
+import requests
+
+from glob import glob
+
+"""
+wdpa.py
+Tony Cannistra
+
+Manages the data access of the World Database of Protected Areas.
+"""
+
+class WDPA(object):
+    """
+    Access WDPA protected areas dataset
+    https://www.protectedplanet.net/
+    """
+
+    ZIP_SHP_DATA_URL = "https://www.protectedplanet.net/downloads/WDPA_Jun2020?type=shapefile"
+    DATA_FILENAME = "WDPA_Jun2020.shp"
+
+    def __init__(self, local_loc=None):
+        self.local_loc = local_loc
+
+    def unzip(self, destination, zipfile=None):
+        """
+        Unzip WDPA database file.
+
+        WDPA Monthly extracts have several sub-files, which we also extract.
+
+        Uses local_loc as zipfile root if zipfile is not specified.
+        """
+        if zipfile is None:
+            zipfile = self.local_loc
+
+        if not os.path.exists(destination):
+            warn(f"Directory {destination} does not exist; creating...")
+            os.makedirs(destination)
+
+        zipdest = os.path.join(destination, WDPA.DATA_FILENAME)
+        _unzip(zipfile, zipdest)
+
+        result_zipfiles = glob(
+            os.path.join(
+                zipdest,
+                "*.zip"
+            )
+        )
+
+        for file in result_zipfiles:
+            rootname = os.path.splitext(file)[0]
+            _unzip(file, rootname)
+
+
+    def download(self, destination):
+        """
+        Download and unzip PAD-US data into destination.
+
+        Throws warning if local_loc was given at class initialization,
+        re-downloading may be unnecessary in this case.
+        """
+        if self.local_loc:
+            warn("Local location of dataset already provided."
+                 "Re-running download in this case will result"
+                 "in extra bandwidth usage and download times.")
+
+        print("Downloading...")
+        with TemporaryDirectory() as td:
+            tmpfile = os.path.join(td, WDPA.DATA_FILENAME+'.zip')
+
+            _download_file(WDPA.ZIP_SHP_DATA_URL, tmpfile)
+
+            print("Unzipping file...")
+            self.unzip(destination, tmpfile)

--- a/landwatch/get/test_util.py
+++ b/landwatch/get/test_util.py
@@ -1,0 +1,27 @@
+import unittest
+import requests
+from os import path
+from .util import _download_file
+from tempfile import TemporaryDirectory
+
+class TestDownloadFile(unittest.TestCase):
+    def test_download(self):
+        test_url = "https://via.placeholder.com/200x150"
+        tmpdir = TemporaryDirectory()
+        outpath_true = path.join(tmpdir.name, "true.html")
+        outpath_test = path.join(tmpdir.name, "test.html")
+
+        with open(outpath_true, 'wb') as f:
+            r = requests.get(test_url)
+            f.write(r.content)
+
+        _download_file(test_url, outpath_test)
+
+        true = open(outpath_true, 'rb') #pragma: no cover
+        test = open(outpath_test, 'rb')
+
+        self.assertEqual(str(true.read()), str(test.read()))
+
+        true.close()
+        test.close()
+        tmpdir.cleanup()

--- a/landwatch/get/util.py
+++ b/landwatch/get/util.py
@@ -1,0 +1,29 @@
+import requests
+from tqdm import tqdm
+from subprocess import Popen
+
+def _download_file(url, destination):
+    r = requests.get(url, stream=True)
+    # Total size in bytes.
+    total_size = int(r.headers.get('content-length', 0))
+
+    block_size = 1024 #1 Kibibyte
+
+    t=tqdm(total=total_size, unit='iB', unit_scale=True)
+
+    with open(destination, 'wb') as f:
+        for data in r.iter_content(block_size):
+
+            t.update(len(data))
+            f.write(data)
+
+    t.close()
+    if total_size != 0 and t.n != total_size:
+        raise Exception(f"Download error (size: {total_size} != {t.n})")
+
+UNZIP_CMD = "unzip -u -o {zipfile} -d {outdir}"
+def _unzip(file, dest):
+    Popen(UNZIP_CMD.format(
+        zipfile = file,
+        outdir = dest
+    ), shell=True).communicate()

--- a/landwatch/test_cli.py
+++ b/landwatch/test_cli.py
@@ -2,12 +2,10 @@ import os
 import unittest
 from .cli import cli_main
 
-
 REQUIRED_MODULES = [
     m for m in next(os.walk(os.path.dirname(__file__)))[1]
     if not m.startswith('__')
 ]
-
 
 class TestGenerateCLI(unittest.TestCase):
     def test_cli(self):


### PR DESCRIPTION
This PR implements the `lands` portion of `get.`

It starts with USGS and WDPA, but I'm not sure which I'm going to focus on yet. The WDPA is great but perhaps doesn't have the necessary metadata for differentiating federal vs non-federal pub.lands in US. USGS does, but it's an annoying dataset and takes _hours_ to download. 